### PR TITLE
채팅 방에 들어가기 전 미리보기 페이지 구현

### DIFF
--- a/routes/room.js
+++ b/routes/room.js
@@ -44,18 +44,20 @@ router.get('/', async (req, res) => {
     });
 });
 
-// // 방에 있는 사용자들의 정보 보내주기
-// router.get('/:room/users', (req, res) => {
-//   // 해당 방에 들어가있는 사용자들 검색
-//   const users = User.findAll(
-//     {
-//       attributes: ['nickname', 'gender', 'image', 'tag', 'level', 'mobumScore'],
-//     },
-//     { where: { roomId: req.params.room } },
-//   );
-
-//   console.log(users);
-// });
+// 방에 있는 사용자들의 정보 보내주기
+router.get('/:room/users', async (req, res) => {
+  // 해당 방에 들어가있는 사용자들 검색
+  await User.findAll({
+    attributes: ['nickname', 'gender', 'image', 'tag', 'level', 'mobum_score'],
+    where: { roomId: req.params.room },
+  })
+    .then(users => {
+      res.send({ users });
+    })
+    .catch(err => {
+      res.status(500).send({ err });
+    });
+});
 
 // 클라이언트가 특정 방에 들어갔음을 확인
 router.post('/:room', (req, res) => {

--- a/routes/room.js
+++ b/routes/room.js
@@ -61,14 +61,11 @@ router.get('/:room/users', async (req, res) => {
 
 // 클라이언트가 특정 방에 들어갔음을 확인
 router.post('/:room', (req, res) => {
-  // 해당 방에 들어가있는 사용자들 검색
-  User.update({ roomId: req.params.room }, { where: { id: req.user.id } })
-    .then(() => {
-      res.send({ userId: req.user.id });
-    })
-    .catch(err => {
-      res.status(500).send({ err });
-    });
+  try {
+    res.send({ userId: req.user.id });
+  } catch (err) {
+    res.status(500).send({ err });
+  }
 });
 
 module.exports = router;

--- a/routes/room.js
+++ b/routes/room.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { v4: uuidV4 } = require('uuid');
 const { Op } = require('sequelize');
 const Room = require('../models/Room');
+const User = require('../models/User');
 
 const router = express.Router();
 
@@ -43,9 +44,29 @@ router.get('/', async (req, res) => {
     });
 });
 
-// 특정 방 들어가기
-router.get('/:room', (req, res) => {
-  res.render('room', { roomId: req.params.room });
+// // 방에 있는 사용자들의 정보 보내주기
+// router.get('/:room/users', (req, res) => {
+//   // 해당 방에 들어가있는 사용자들 검색
+//   const users = User.findAll(
+//     {
+//       attributes: ['nickname', 'gender', 'image', 'tag', 'level', 'mobumScore'],
+//     },
+//     { where: { roomId: req.params.room } },
+//   );
+
+//   console.log(users);
+// });
+
+// 클라이언트가 특정 방에 들어갔음을 확인
+router.post('/:room', (req, res) => {
+  // 해당 방에 들어가있는 사용자들 검색
+  User.update({ roomId: req.params.room }, { where: { id: req.user.id } })
+    .then(() => {
+      res.send({ userId: req.user.id });
+    })
+    .catch(err => {
+      res.status(500).send({ err });
+    });
 });
 
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -115,7 +115,7 @@ router.post('/login', isNotLoggedIn, (req, res, next) => {
             httpOnly: true,
             maxAge: 1000 * 60 * 60 * 24 * 14,
           });
-          res.json({ accessToken });
+          res.json({ accessToken, userId: user.id });
         });
       },
     )(req, res, next);


### PR DESCRIPTION
## #16 

#16 채팅 방에 들어가기 전 미리보기 페이지 구현

## 작업 내역

- 사용자가 소켓 서버로 보낼 자신의 userId를 알기 위해 서버로 요청을 보냄
> `room/:room` post 요청
- 어떤 사용자가 방에 들어가고 나가는지 확인하여 DB에 업데이트
> bin/www.js에서 'join-room'과 'disconnect' 이벤트때마다 사용자의 userId를 확인하여 DB에서 해당 유저의 roomId를 업데이트

- 클라이언트에서 방 번호를 주며 요청을 하면 해당 방에 들어가있는 사용자들을 검색
- 해당 사용자들의 닉네임, 프로필, 성별, 태그, 레벨, 점수 정보를 응답
> `room/:room/users` post 요청으로 해당 방에 참여중인 user들의 정보를 응답으로 전송

## 리뷰받고 싶은 포인트

- 사용자가 소켓 서버로 보낼 자신의 userId를 알기 위해 서버로 요청을 보냄
> `room/:room` post 요청
 => 요청의 api 형식이 목적에 부합하지 않고, 클라이언트에서 매번 자신의 정보를 알고 싶을때마다 서버로 요청을 보내야하는지도 의문